### PR TITLE
feat: Add additional typings to plugin export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -159,5 +159,10 @@ export type {
   ItemAccessFunction,
   SidebarComponent,
   SidebarTabCustom,
+  SidebarTabContent,
+  SidebarTabLink,
+  SidebarTabItem,
+  IconName,
   TabAccessFunction,
+  TabIconConfig,
 } from './types.js'

--- a/src/types.ts
+++ b/src/types.ts
@@ -150,7 +150,7 @@ export type SidebarComponent =
 /**
  * Mutually exclusive icon config: either a Lucide icon name OR a custom icon component path.
  */
-type TabIconConfig =
+export type TabIconConfig =
   | {
       /** Icon name from lucide-react */
       icon: IconName


### PR DESCRIPTION
# Overview
Adds typings for `SidebarTabContent`, `SidebarTabLink`, `SidebarTabItem`, `IconName`, and `TabIconConfig` to the main plugin export

## Changes
1. src/types.ts: Adds export for type TabIconConfig
2. src/index.ts: exports `SidebarTabContent`, `SidebarTabLink`, `SidebarTabItem`, `IconName`, and `TabIconConfig`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the public API by exporting sidebar, tab, and icon configuration types for developers to use in their implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->