### PR TITLE
feat: adjusted z-index on sidebar tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veiag/payload-enhanced-sidebar",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "An enhanced sidebar plugin for Payload CMS with tabbed navigation to organize collections and globals.",
   "author": "VeiaG",
   "license": "MIT",

--- a/src/components/EnhancedSidebar/SettingsMenuButton/index.scss
+++ b/src/components/EnhancedSidebar/SettingsMenuButton/index.scss
@@ -13,7 +13,9 @@
       background: transparent;
       color: var(--theme-elevation-500);
       cursor: pointer;
-      transition: all 150ms ease;
+      transition:
+        background 150ms ease,
+        color 150ms ease;
 
       &:hover {
         background: var(--theme-elevation-100);

--- a/src/components/EnhancedSidebar/SidebarWrapper/index.scss
+++ b/src/components/EnhancedSidebar/SidebarWrapper/index.scss
@@ -29,7 +29,9 @@
       top: 0;
       width: 100vw;
       height: var(--app-header-height);
-      z-index: 1;
+      // Must stay above `.tabs-bar` (z-index: 5), otherwise the bar covers the mobile
+      // close button, which sits in this header over the left column.
+      z-index: 10;
     }
 
     &__mobile-close {

--- a/src/components/EnhancedSidebar/TabsBar/index.scss
+++ b/src/components/EnhancedSidebar/TabsBar/index.scss
@@ -11,6 +11,14 @@
     padding: base(0.5) 0;
     border-right: 1px solid var(--theme-elevation-100);
     background: var(--theme-elevation-50);
+    // The whole bar owns a stacking context that sits above `.enhanced-sidebar__content`.
+    // Tooltips are absolutely positioned inside the tab buttons, and a button can gain its
+    // own stacking context at any time (composited transition, layer promotion), which traps
+    // the tooltip's own z-index. Lifting the bar itself keeps tooltips above the nav links
+    // no matter what happens inside. Scoped to the sidebar, since `.enhanced-sidebar` is
+    // `position: sticky` and therefore already a stacking context of its own.
+    position: relative;
+    z-index: 5;
 
     [dir='rtl'] & {
       border-right: none;
@@ -35,7 +43,9 @@
         top: 50%;
         transform: translateY(-50%);
         white-space: nowrap;
-        //Force z-index to very high value, to prevent it from being hidden by other elements
+        // Above siblings inside the button. Staying above the nav links is handled by the
+        // stacking context on `.tabs-bar` — this value alone is not enough, since the button
+        // can become a stacking context and scope it.
         z-index: 1000;
 
         // Neutralize the top/bottom transform that Payload applies
@@ -80,7 +90,12 @@
       background: transparent;
       color: var(--theme-elevation-500);
       cursor: pointer;
-      transition: all 150ms ease;
+      // Only the properties that actually change on hover — `all` also covers `transform`
+      // and `opacity`, which lets the browser promote the button to its own layer and trap
+      // the tooltip's z-index inside it.
+      transition:
+        background 150ms ease,
+        color 150ms ease;
       text-decoration: none;
 
       &:hover {
@@ -156,7 +171,9 @@
       background: transparent;
       color: var(--theme-elevation-500);
       cursor: pointer;
-      transition: all 150ms ease;
+      transition:
+        background 150ms ease,
+        color 150ms ease;
       text-decoration: none;
 
       &:hover {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile sidebar layering so the close button remains visible.
  * Ensured tab tooltips display above sidebar content.

* **Style**
  * Smoothed sidebar menu, tab, and action transitions by limiting animations to background and color changes.

* **Chores**
  * Updated the package version to 0.4.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->