### PR TITLE
feat: linked tabs and client exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An enhanced sidebar plugin for [Payload CMS](https://payloadcms.com) that adds a
 
 - **Tabbed Navigation** - Organize collections into separate tabs for cleaner navigation
 - **Vertical Tab Bar** - Icon-based tabs on the left side of the sidebar
-- **Link Support** - Add navigation links (like Dashboard) alongside tabs
+- **Link Support** - Add navigation links (like Dashboard) alongside tabs, or give a tab its own `href` so it navigates *and* opens its panel
 - **Custom Items** - Add custom navigation items that can be merged into existing groups
 - **Badges** - Show notification badges on tabs and navigation items (API-based or reactive provider)
 - **Custom Components** - Replace any part of the sidebar with your own React components
@@ -166,11 +166,44 @@ Array of tabs and links to show in the sidebar.
 | `globals` | `GlobalSlug[]` | No | Globals to show in this tab |
 | `customItems` | `SidebarTabItem[]` | No | Custom navigation items (see below) |
 | `badge` | `BadgeConfig` | No | Badge configuration for the tab icon |
+| `href` | `string` | No | Makes the tab navigate as well as open its panel. Relative to the admin route (see below) |
 | `position` | `'top' \| 'bottom'` | No | `'bottom'` pins the tab to the bottom of the bar, above the actions (default `'top'`) |
 | `access` | `TabAccessFunction` | No | Server-side access control — return `false` to hide |
 
 > \* Exactly one of `icon` or `iconComponent` is required — they are mutually exclusive.
 > If neither `collections` nor `globals` are specified, the tab shows all collections and globals.
+
+**Tabs that are also links (`href` on a tab)**
+
+By default a `tab` opens a panel and a `link` navigates — one or the other. Give a tab an `href` and it does both: a click navigates **and** opens the tab's panel, so its child items stay visible. This is what you want for a Dashboard tab that should open `/admin` while still showing its own shortcuts.
+
+```typescript
+tabs: [
+  {
+    id: 'dashboard',
+    type: 'tab',
+    href: '/',                 // relative to the admin route → /admin
+    icon: 'House',
+    label: 'Dashboard',
+    customItems: [
+      { slug: 'new-post', href: '/collections/posts/create', label: 'New Post' },
+    ],
+  },
+]
+```
+
+Click behavior:
+
+| Click | Result |
+|-------|--------|
+| Plain left-click | Navigates to `href` **and** opens the tab's panel |
+| ⌘ / Ctrl / Shift / Alt click, middle-click | Navigates only — a click that lands in a new tab/window leaves the current window's panel exactly as it was |
+
+A tab's `href` is always relative to the admin route — there is no `isExternal` here. An external href opens in a new browser tab, which would leave this window untouched and the tab's panel unreachable. Use `type: 'link'` for external destinations.
+
+The tab renders as a real anchor, so "Open in new tab", link previews and keyboard activation all work as expected.
+
+Such a tab shows two independent states: the background highlight marks the **open panel**, while the left-edge bar marks the **current route** — so it stays visible as the active panel even after you navigate away.
 
 
 **Link (`type: 'link'`)**
@@ -416,7 +449,7 @@ For reactive badges (real-time updates, websockets, etc.), use the `BadgeProvide
 // components/MyBadgeProvider.tsx
 'use client'
 
-import { BadgeProvider } from '@veiag/payload-enhanced-sidebar'
+import { BadgeProvider } from '@veiag/payload-enhanced-sidebar/client'
 import { useEffect, useState } from 'react'
 
 export const MyBadgeProvider = ({ children }) => {

--- a/dev/payload.config.ts
+++ b/dev/payload.config.ts
@@ -426,13 +426,29 @@ const buildConfigWithMemoryDB = async () => {
           },
         },
         tabs: [
+          // Tab + href: clicking it opens the dashboard *and* the tab's own panel,
+          // so the shortcuts below stay visible. Cmd/Ctrl-click only navigates.
           {
             id: 'dashboard',
-            type: 'link',
+            type: 'tab',
             href: '/',
+            customItems: [
+              {
+                slug: 'dashboard-new-post',
+                group: { en: 'Shortcuts', uk: 'Ярлики' },
+                href: '/collections/posts/create',
+                label: { en: 'New Post', uk: 'Новий пост' },
+              },
+              {
+                slug: 'dashboard-account',
+                group: { en: 'Shortcuts', uk: 'Ярлики' },
+                href: '/account',
+                label: { en: 'My Account', uk: 'Мій акаунт' },
+              },
+            ],
             iconComponent: './components/CustomNavComponents#CustomTabIcon',
             label: { en: 'Dashboard', uk: 'Головна' },
-            // access: always granted — link is visible
+            // access: always granted — tab is visible
             access: ({ req }) => Boolean(req.user),
           },
           {
@@ -613,6 +629,16 @@ const buildConfigWithMemoryDB = async () => {
             icon: 'Settings',
             label: { en: 'Settings', uk: 'Налаштування' },
             // Render this tab at the bottom of the bar, above folders/settings/logout
+            position: 'bottom',
+          },
+          // Plain link — navigates only, opens no panel
+          {
+            id: 'docs',
+            type: 'link',
+            href: 'https://payload.veiag.dev/',
+            icon: 'BookOpen',
+            isExternal: true,
+            label: { en: 'Docs', uk: 'Документація' },
             position: 'bottom',
           },
         ],

--- a/docs/custom-components.md
+++ b/docs/custom-components.md
@@ -692,7 +692,7 @@ payloadEnhancedSidebar({
 
 | Hook | Import | Description |
 |------|--------|-------------|
-| `useNavItemState(href)` | `@veiag/payload-enhanced-sidebar` | `{ isActive, isCurrentPage }` for a nav item |
-| `useTabState(id)` | `@veiag/payload-enhanced-sidebar` | `{ isActive }` for a tab id |
-| `useEnhancedSidebar()` | `@veiag/payload-enhanced-sidebar` | `{ activeTabId, onTabChange }` context |
-| `useBadgeValue(slug)` | `@veiag/payload-enhanced-sidebar` | Current badge value from BadgeProvider |
+| `useNavItemState(href)` | `@veiag/payload-enhanced-sidebar/client` | `{ isActive, isCurrentPage }` for a nav item |
+| `useTabState(id)` | `@veiag/payload-enhanced-sidebar/client` | `{ isActive }` for a tab id |
+| `useEnhancedSidebar()` | `@veiag/payload-enhanced-sidebar/client` | `{ activeTabId, onTabChange }` context |
+| `useBadgeValue(slug)` | `@veiag/payload-enhanced-sidebar/client` | Current badge value from BadgeProvider |

--- a/docs/custom-components.md
+++ b/docs/custom-components.md
@@ -16,6 +16,25 @@ The plugin allows replacing every visual piece of the sidebar with your own Reac
 
 All paths follow Payload's component format: `'./path/to/file#ExportName'`.
 
+## Importing hooks and providers
+
+Inside a `'use client'` file, import from the `/client` subpath:
+
+```tsx
+'use client'
+
+import {
+  BadgeProvider,
+  useBadgeContext,
+  useBadgeValue,
+  useEnhancedSidebar,
+  useNavItemState,
+  useTabState,
+} from '@veiag/payload-enhanced-sidebar/client'
+```
+
+The same names are re-exported from the package root, but the root entry also carries the plugin itself (and with it `payload`), which does not belong in a client bundle. Prop types (`CustomNavItemProps`, `CustomTabButtonProps`, …) are available from both.
+
 ---
 
 ## NavItem
@@ -46,7 +65,7 @@ Use the `useNavItemState(href)` hook to get reactive active state:
 'use client'
 
 import type { CustomNavItemProps } from '@veiag/payload-enhanced-sidebar'
-import { useNavItemState } from '@veiag/payload-enhanced-sidebar'
+import { useNavItemState } from '@veiag/payload-enhanced-sidebar/client'
 import { Link } from '@payloadcms/ui'
 
 export const MyNavItem: React.FC<CustomNavItemProps> = ({ entity, href, id, label }) => {
@@ -72,7 +91,7 @@ export const MyNavItem: React.FC<CustomNavItemProps> = ({ entity, href, id, labe
 **`useNavItemState(href)`**
 
 ```typescript
-import { useNavItemState } from '@veiag/payload-enhanced-sidebar'
+import { useNavItemState } from '@veiag/payload-enhanced-sidebar/client'
 
 const { isActive, isCurrentPage } = useNavItemState(href)
 // isActive      — true when current path starts with href (e.g. /admin/collections/posts/*)
@@ -157,7 +176,7 @@ Use the `useTabState(id)` hook to know which tab is active:
 'use client'
 
 import type { CustomNavContentProps } from '@veiag/payload-enhanced-sidebar'
-import { useTabState } from '@veiag/payload-enhanced-sidebar'
+import { useTabState } from '@veiag/payload-enhanced-sidebar/client'
 
 export const MyNavContent: React.FC<CustomNavContentProps> = ({
   tabs,
@@ -196,7 +215,7 @@ const TabPanel = ({ id, tabsContent }) => {
 **`useTabState(id)`**
 
 ```typescript
-import { useTabState } from '@veiag/payload-enhanced-sidebar'
+import { useTabState } from '@veiag/payload-enhanced-sidebar/client'
 
 const { isActive } = useTabState('my-tab-id')
 // true when this tab is the currently selected one
@@ -225,8 +244,10 @@ payloadEnhancedSidebar({
 | `label` | `string` | Pre-translated label |
 | `icon` | `ReactNode` | Pre-rendered icon (from `iconComponent` or default Lucide) |
 | `badge` | `BadgeConfig \| undefined` | Badge config |
-| `href` | `string \| undefined` | Computed href (only for `link` type) |
-| `isExternal` | `boolean \| undefined` | Whether link is external (only for `link` type) |
+| `href` | `string \| undefined` | Computed href. Always set for `link` items; set for `tab` items only when they declare an `href` |
+| `isExternal` | `boolean \| undefined` | Whether the link is external. Only ever set for `link` items — a tab's `href` is admin-relative |
+
+Since a `tab` [can also carry an `href`](../README.md#tabs), `href` — not `type` — decides whether you render an anchor or a button. A `tab` with an `href` must do both: navigate and switch the panel. Skip the tab switch on modifier and middle clicks — those land in a new tab/window, and the current one must keep the panel it already has.
 
 Use `useTabState` and `useEnhancedSidebar` for state:
 
@@ -234,7 +255,7 @@ Use `useTabState` and `useEnhancedSidebar` for state:
 'use client'
 
 import type { CustomTabButtonProps } from '@veiag/payload-enhanced-sidebar'
-import { useEnhancedSidebar, useTabState } from '@veiag/payload-enhanced-sidebar'
+import { useEnhancedSidebar, useTabState } from '@veiag/payload-enhanced-sidebar/client'
 
 export const MyTabButton: React.FC<CustomTabButtonProps> = ({
   id, type, label, icon, href, isExternal,
@@ -242,14 +263,22 @@ export const MyTabButton: React.FC<CustomTabButtonProps> = ({
   const { isActive } = useTabState(id)
   const { onTabChange } = useEnhancedSidebar()
 
-  if (type === 'link' && href) {
+  if (href) {
     return (
       <a
         href={href}
+        onClick={(e) => {
+          // Lands in a new tab/window? Then don't touch this window's panel
+          const opensElsewhere =
+            e.button !== 0 || e.altKey || e.ctrlKey || e.metaKey || e.shiftKey
+          if (type === 'tab' && !opensElsewhere) {
+            onTabChange(id)
+          }
+        }}
         rel={isExternal ? 'noopener noreferrer' : undefined}
         target={isExternal ? '_blank' : undefined}
         title={label}
-        style={{ opacity: isActive ? 1 : 0.5 }}
+        style={{ opacity: type === 'tab' && isActive ? 1 : 0.5 }}
       >
         {icon}
       </a>
@@ -257,7 +286,12 @@ export const MyTabButton: React.FC<CustomTabButtonProps> = ({
   }
 
   return (
-    <button onClick={() => onTabChange(id)} title={label} type="button">
+    <button
+      onClick={() => onTabChange(id)}
+      title={label}
+      type="button"
+      style={{ opacity: isActive ? 1 : 0.5 }}
+    >
       {icon}
     </button>
   )
@@ -267,7 +301,7 @@ export const MyTabButton: React.FC<CustomTabButtonProps> = ({
 **`useEnhancedSidebar()`**
 
 ```typescript
-import { useEnhancedSidebar } from '@veiag/payload-enhanced-sidebar'
+import { useEnhancedSidebar } from '@veiag/payload-enhanced-sidebar/client'
 
 const { activeTabId, onTabChange } = useEnhancedSidebar()
 // activeTabId  — currently selected tab id

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veiag/payload-enhanced-sidebar",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "An enhanced sidebar plugin for Payload CMS with tabbed navigation to organize collections and globals.",
   "author": "VeiaG",
   "license": "MIT",

--- a/src/components/EnhancedSidebar/BadgeProvider/index.tsx
+++ b/src/components/EnhancedSidebar/BadgeProvider/index.tsx
@@ -41,7 +41,7 @@ export type BadgeProviderProps = {
  * @example
  * ```tsx
  * // In your admin.components.providers
- * import { BadgeProvider } from '@veiag/payload-enhanced-sidebar'
+ * import { BadgeProvider } from '@veiag/payload-enhanced-sidebar/client'
  *
  * export const MyProvider = ({ children }) => {
  *   const [counts, setCounts] = useState({ orders: 0 })

--- a/src/components/EnhancedSidebar/TabsBar/TabItem.tsx
+++ b/src/components/EnhancedSidebar/TabsBar/TabItem.tsx
@@ -12,40 +12,100 @@ import { Icon } from '../Icon.js'
 
 const tabsBaseClass = 'tabs-bar'
 
+/**
+ * True for clicks that land in a new tab/window instead of this one — modifier
+ * clicks and middle clicks. Payload's `Link` already swallows these before it
+ * calls `onClick`; we re-check so the rule is ours and not inherited.
+ */
+const opensElsewhere = (e: React.MouseEvent): boolean =>
+  e.defaultPrevented || e.button !== 0 || e.altKey || e.ctrlKey || e.metaKey || e.shiftKey
+
 type TabButtonProps = {
+  /** Computed href — set only for tabs that declare one; makes the tab render as a link */
+  href?: string
   icon?: React.ReactNode
+  /** Whether this tab's panel is the open one */
   isActive: boolean
+  /** Whether the current route matches `href` (only meaningful for linked tabs) */
+  isCurrentPage?: boolean
   onTabChange: (tabId: string) => void
   tab: SidebarTabContent
 }
 
-export const TabButton: React.FC<TabButtonProps> = ({ icon, isActive, onTabChange, tab }) => {
+export const TabButton: React.FC<TabButtonProps> = ({
+  href,
+  icon,
+  isActive,
+  isCurrentPage,
+  onTabChange,
+  tab,
+}) => {
   const { i18n } = useTranslation()
   const label = getTranslation(tab.label, i18n)
   const { value } = useBadge(tab.badge, tab.id)
   const [hovered, setHovered] = useState(false)
 
-  return (
+  const className = [
+    `${tabsBaseClass}__tab`,
+    isActive && `${tabsBaseClass}__tab--active`,
+    // Route-match indicator, only ever set on a linked tab
+    isCurrentPage && `${tabsBaseClass}__tab--current`,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  const content = (
     <>
-      <button
-        aria-label={label}
-        className={`${tabsBaseClass}__tab ${isActive ? `${tabsBaseClass}__tab--active` : ''}`}
-        onBlur={() => setHovered(false)}
-        onClick={() => onTabChange(tab.id)}
-        onFocus={() => setHovered(true)}
-        onMouseEnter={() => setHovered(true)}
-        onMouseLeave={() => setHovered(false)}
-        type="button"
-      >
-        {icon ?? <Icon name={tab.icon!} size={20} />}
-        {value !== undefined && (
-          <Badge color={tab.badge?.color} position="absolute" value={value} />
-        )}
-        <Tooltip alignCaret="left" show={hovered}>
-          {label}
-        </Tooltip>
-      </button>
+      {icon ?? <Icon name={tab.icon!} size={20} />}
+      {value !== undefined && <Badge color={tab.badge?.color} position="absolute" value={value} />}
+      <Tooltip alignCaret="left" show={hovered}>
+        {label}
+      </Tooltip>
     </>
+  )
+
+  const hoverHandlers = {
+    onBlur: () => setHovered(false),
+    onFocus: () => setHovered(true),
+    onMouseEnter: () => setHovered(true),
+    onMouseLeave: () => setHovered(false),
+  }
+
+  // A tab with an href navigates *and* opens its panel, so it has to be a real
+  // anchor — that keeps middle/modifier clicks, "open in new tab" and link
+  // previews working.
+  if (href !== undefined) {
+    return (
+      <Link
+        aria-current={isCurrentPage ? 'page' : undefined}
+        aria-label={label}
+        className={className}
+        href={href}
+        {...hoverHandlers}
+        onClick={(e) => {
+          // A click that lands in a new tab/window leaves this one as it was,
+          // panel included.
+          if (opensElsewhere(e)) {
+            return
+          }
+          onTabChange(tab.id)
+        }}
+      >
+        {content}
+      </Link>
+    )
+  }
+
+  return (
+    <button
+      aria-label={label}
+      className={className}
+      {...hoverHandlers}
+      onClick={() => onTabChange(tab.id)}
+      type="button"
+    >
+      {content}
+    </button>
   )
 }
 

--- a/src/components/EnhancedSidebar/TabsBar/index.scss
+++ b/src/components/EnhancedSidebar/TabsBar/index.scss
@@ -109,26 +109,28 @@
       color: var(--theme-text);
     }
 
-    &__link {
-      &--active {
-        color: var(--theme-text);
+    // Route indicator. Set on links whose href matches the current URL, and on
+    // tabs that carry an `href` — for those the background highlight still tracks
+    // which panel is open, while this bar tracks where the browser actually is.
+    &__link--active,
+    &__tab--current {
+      color: var(--theme-text);
 
-        &::before {
-          content: '';
-          position: absolute;
-          left: -6px;
-          top: 50%;
-          transform: translateY(-50%);
-          width: 3px;
-          height: 20px;
-          background: var(--theme-text);
-          border-radius: 0 2px 2px 0;
+      &::before {
+        content: '';
+        position: absolute;
+        left: -6px;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 3px;
+        height: 20px;
+        background: var(--theme-text);
+        border-radius: 0 2px 2px 0;
 
-          [dir='rtl'] & {
-            left: auto;
-            right: -6px;
-            border-radius: 2px 0 0 2px;
-          }
+        [dir='rtl'] & {
+          left: auto;
+          right: -6px;
+          border-radius: 2px 0 0 2px;
         }
       }
     }

--- a/src/components/EnhancedSidebar/TabsBar/index.tsx
+++ b/src/components/EnhancedSidebar/TabsBar/index.tsx
@@ -6,7 +6,12 @@ import { usePathname } from 'next/navigation.js'
 import { formatAdminURL } from 'payload/shared'
 import React from 'react'
 
-import type { EnhancedSidebarConfig, SidebarTab } from '../../../types.js'
+import type {
+  EnhancedSidebarConfig,
+  SidebarTab,
+  SidebarTabContent,
+  SidebarTabLink,
+} from '../../../types.js'
 
 import { Icon } from '../Icon.js'
 import { SettingsMenuButton } from '../SettingsMenuButton/index.js'
@@ -56,16 +61,38 @@ export const TabsBar: React.FC<TabsBarProps> = ({
   })
   const isFoldersActive = pathname.startsWith(folderURL)
 
+  /**
+   * Resolves a configured href to a full URL and whether it matches the current route.
+   * `href` is required on links and optional on tabs (a tab with an href both
+   * navigates and opens its panel).
+   */
+  const resolveHref = (
+    item: SidebarTabContent | SidebarTabLink,
+  ): { href: string; isCurrentPage: boolean } | undefined => {
+    if (item.href === undefined) {
+      return undefined
+    }
+    const href = item.isExternal ? item.href : formatAdminURL({ adminRoute, path: item.href })
+    return {
+      href,
+      isCurrentPage: pathname === href || (item.href === '/' && pathname === adminRoute),
+    }
+  }
+
   const renderTabItem = (item: SidebarTab) => {
     if (item.type === 'custom') {
       return customTabComponents?.[item.id] ?? null
     }
 
+    const resolved = resolveHref(item)
+
     if (item.type === 'tab') {
       return (
         <TabButton
+          href={resolved?.href}
           icon={tabIcons?.[item.id]}
           isActive={activeTabId === item.id}
+          isCurrentPage={resolved?.isCurrentPage}
           key={item.id}
           onTabChange={onTabChange}
           tab={item}
@@ -73,13 +100,15 @@ export const TabsBar: React.FC<TabsBarProps> = ({
       )
     }
 
-    // Check if link is active
-    const href = item.isExternal
-      ? item.href
-      : formatAdminURL({ adminRoute, path: item.href })
-    const isActive = pathname === href || (item.href === '/' && pathname === adminRoute)
-
-    return <TabLink href={href} icon={tabIcons?.[item.id]} isActive={isActive} key={item.id} link={item} />
+    return (
+      <TabLink
+        href={resolved!.href}
+        icon={tabIcons?.[item.id]}
+        isActive={resolved!.isCurrentPage}
+        key={item.id}
+        link={item}
+      />
+    )
   }
 
   const tabItems = sidebarConfig.tabs ?? []

--- a/src/components/EnhancedSidebar/hooks/useNavItemState.ts
+++ b/src/components/EnhancedSidebar/hooks/useNavItemState.ts
@@ -9,7 +9,7 @@ import { usePathname } from 'next/navigation.js'
  * @example
  * ```tsx
  * 'use client'
- * import { useNavItemState } from '@veiag/payload-enhanced-sidebar'
+ * import { useNavItemState } from '@veiag/payload-enhanced-sidebar/client'
  *
  * export const MyNavItem = ({ href, label }) => {
  *   const { isActive, isCurrentPage } = useNavItemState(href)

--- a/src/components/EnhancedSidebar/index.tsx
+++ b/src/components/EnhancedSidebar/index.tsx
@@ -457,9 +457,10 @@ export const EnhancedSidebar: React.FC<EnhancedSidebarProps> = async (props) => 
       }
 
       if (hasCustomTabButton) {
-        // Compute href for links
+        // Compute href — required on links, optional on tabs (a tab with an href
+        // both navigates and opens its panel).
         let href: string | undefined
-        if (item.type === 'link') {
+        if (item.href !== undefined) {
           href = item.isExternal ? item.href : formatAdminURL({ adminRoute, path: item.href })
         }
 
@@ -474,7 +475,7 @@ export const EnhancedSidebar: React.FC<EnhancedSidebarProps> = async (props) => 
               badge: item.badge,
               href,
               icon: iconNode,
-              isExternal: item.type === 'link' ? item.isExternal : undefined,
+              isExternal: item.isExternal,
               label,
               ...tabBtnExtraProps,
             },

--- a/src/exports/client.ts
+++ b/src/exports/client.ts
@@ -1,2 +1,32 @@
+// Hooks and providers for your own client components.
+// Also exported from the package root, but importing them from there pulls the
+// plugin (and `payload` itself) into the client bundle — import from
+// `@veiag/payload-enhanced-sidebar/client` inside `'use client'` files.
+export {
+  BadgeProvider,
+  useBadgeContext,
+  useBadgeValue,
+} from '../components/EnhancedSidebar/BadgeProvider/index.js'
+export type { BadgeProviderProps } from '../components/EnhancedSidebar/BadgeProvider/index.js'
+export { useEnhancedSidebar } from '../components/EnhancedSidebar/context.js'
+export type { EnhancedSidebarContextValue } from '../components/EnhancedSidebar/context.js'
+export { useNavItemState } from '../components/EnhancedSidebar/hooks/useNavItemState.js'
+export { useTabState } from '../components/EnhancedSidebar/hooks/useTabState.js'
+
 // Client components exported for Payload's component system
 export { InternalBadgeProvider } from '../components/EnhancedSidebar/InternalBadgeProvider/index.js'
+
+export type {
+  BadgeColor,
+  BadgeConfig,
+  BadgeValues,
+  CustomNavContentProps,
+  CustomNavGroupProps,
+  CustomNavItemComponentProps,
+  CustomNavItemProps,
+  CustomTabButtonProps,
+  CustomTabIconProps,
+  CustomTabsBarComponentProps,
+  ExtendedEntity,
+  IconName,
+} from '../types.js'

--- a/src/types.ts
+++ b/src/types.ts
@@ -198,16 +198,9 @@ type TabHrefSelf = {
   href: '' | `/${string}`
   isExternal?: never
 }
-/** No href at all — the tab only opens its panel. */
+/** A tab with no href — clicking it only opens its panel. */
 type TabHrefNone = {
-  /**
-   * Optional href, relative to the admin route. When set, the tab doubles as a
-   * link: a plain click navigates **and** opens the tab's panel, so a Dashboard
-   * tab can open `/admin` while its child items stay visible.
-   *
-   * Modifier and middle clicks navigate only — they open a new tab/window and
-   * leave this window's panel untouched.
-   */
+  /** @see {@link TabHrefSelf.href} */
   href?: never
   isExternal?: never
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,9 +167,52 @@ export type TabIconConfig =
     }
 
 /**
- * Sidebar tab that shows content when selected
+ * Href config for a `link` in the tabs bar.
+ * Split into external/internal so `href` can be typed strictly for each case.
  */
-export type SidebarTabContent = {
+type TabHrefExternal = {
+  /** Link href (absolute URL) */
+  href: string
+  isExternal: true
+}
+type TabHrefInternal = {
+  /** Link href (relative to admin route) */
+  href: '' | `/${string}`
+  isExternal?: false
+}
+
+/**
+ * Href config for a `tab`. Admin-relative only — an external href would open in a
+ * new browser tab, leaving this window (and therefore the tab's panel) untouched,
+ * so the panel could never be opened by clicking. Use `type: 'link'` for those.
+ */
+type TabHrefSelf = {
+  /**
+   * Optional href, relative to the admin route. When set, the tab doubles as a
+   * link: a plain click navigates **and** opens the tab's panel, so a Dashboard
+   * tab can open `/admin` while its child items stay visible.
+   *
+   * Modifier and middle clicks navigate only — they open a new tab/window and
+   * leave this window's panel untouched.
+   */
+  href: '' | `/${string}`
+  isExternal?: never
+}
+/** No href at all — the tab only opens its panel. */
+type TabHrefNone = {
+  /**
+   * Optional href, relative to the admin route. When set, the tab doubles as a
+   * link: a plain click navigates **and** opens the tab's panel, so a Dashboard
+   * tab can open `/admin` while its child items stay visible.
+   *
+   * Modifier and middle clicks navigate only — they open a new tab/window and
+   * leave this window's panel untouched.
+   */
+  href?: never
+  isExternal?: never
+}
+
+type SidebarTabContentBase = {
   /**
    * Access control function. Called server-side with the current request.
    * Return `false` to hide this tab (button + content) entirely.
@@ -213,6 +256,13 @@ export type SidebarTabContent = {
   type: 'tab'
 } & TabIconConfig
 
+/**
+ * Sidebar tab that shows content when selected.
+ *
+ * With an optional `href` it also acts as a link — see {@link TabHrefSelf.href}.
+ */
+export type SidebarTabContent = SidebarTabContentBase & (TabHrefNone | TabHrefSelf)
+
 type SidebarTabLinkBase = {
   /**
    * Access control function. Called server-side with the current request.
@@ -238,20 +288,10 @@ type SidebarTabLinkBase = {
   position?: 'bottom' | 'top'
   type: 'link'
 } & TabIconConfig
-type SidebarTabLinkExternal = {
-  /** Link href (absolute URL) */
-  href: string
-  isExternal: true
-} & SidebarTabLinkBase
-type SidebarTabLinkInternal = {
-  /** Link href (relative to admin route) */
-  href: '' | `/${string}`
-  isExternal?: false
-} & SidebarTabLinkBase
 /**
  * Sidebar link that navigates to a URL (not a tab)
  */
-export type SidebarTabLink = SidebarTabLinkExternal | SidebarTabLinkInternal
+export type SidebarTabLink = SidebarTabLinkBase & (TabHrefExternal | TabHrefInternal)
 /**
  * A custom component rendered in the tabs bar (spacer, separator, badge, etc.).
  * Does not open any content — it's purely a visual slot in the tabs column.
@@ -403,7 +443,7 @@ export type SidebarTabItem = CustomComponentItem | ExternalHrefItem | InternalHr
  * ```tsx
  * 'use client'
  * import React from 'react'
- * import { useNavItemState } from '@veiag/payload-enhanced-sidebar'
+ * import { useNavItemState } from '@veiag/payload-enhanced-sidebar/client'
  * import type { CustomNavItemProps } from '@veiag/payload-enhanced-sidebar'
  *
  * export const MyNavItem: React.FC<CustomNavItemProps> = ({ entity, href, id, label, badgeConfig }) => {
@@ -478,17 +518,40 @@ export type CustomTabIconProps = {
  * Use `useTabState(id)` for tab active state, or `usePathname()` for link active state.
  * Use `useEnhancedSidebar().onTabChange` to trigger tab switches.
  *
+ * A `tab` may also carry an `href` — then it should navigate *and* open its panel.
+ * Render it as an anchor, and skip the tab switch on modifier/middle clicks: those
+ * land in a new tab/window, so this one keeps the panel it already has.
+ *
  * @example
  * ```tsx
  * 'use client'
  * import React from 'react'
  * import type { CustomTabButtonProps } from '@veiag/payload-enhanced-sidebar'
- * import { useTabState, useEnhancedSidebar } from '@veiag/payload-enhanced-sidebar'
+ * import { useTabState, useEnhancedSidebar } from '@veiag/payload-enhanced-sidebar/client'
  *
- * export const MyTabButton: React.FC<CustomTabButtonProps> = ({ id, type, icon, label, href }) => {
+ * export const MyTabButton: React.FC<CustomTabButtonProps> = ({
+ *   href, icon, id, isExternal, label, type,
+ * }) => {
  *   const { isActive } = useTabState(id)
  *   const { onTabChange } = useEnhancedSidebar()
- *   if (type === 'link') return <a href={href}>{icon}{label}</a>
+ *
+ *   if (href) {
+ *     return (
+ *       <a
+ *         href={href}
+ *         onClick={(e) => {
+ *           const elsewhere =
+ *             e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey
+ *           if (type === 'tab' && !elsewhere) { onTabChange(id) }
+ *         }}
+ *         rel={isExternal ? 'noopener noreferrer' : undefined}
+ *         target={isExternal ? '_blank' : undefined}
+ *       >
+ *         {icon}{label}
+ *       </a>
+ *     )
+ *   }
+ *
  *   return <button onClick={() => onTabChange(id)}>{icon}{label}</button>
  * }
  * ```
@@ -496,13 +559,16 @@ export type CustomTabIconProps = {
 export type CustomTabButtonProps = {
   /** Badge configuration as defined in the plugin config */
   badge?: BadgeConfig
-  /** Computed href (for link type, with admin route prefix applied) */
+  /**
+   * Computed href, with the admin route prefix applied.
+   * Always set for `link` items; set for `tab` items only when they declare an `href`.
+   */
   href?: string
   /** Pre-rendered icon — either from `iconComponent` or the default Lucide icon */
   icon: ReactNode
   /** Tab/link id */
   id: string
-  /** Whether the link is external (only set for link type) */
+  /** Whether the link is external. Only ever set for `link` items — a tab's `href` is admin-relative */
   isExternal?: boolean
   /** Pre-translated label */
   label: string
@@ -520,7 +586,7 @@ export type CustomTabButtonProps = {
  * ```tsx
  * 'use client'
  * import type { CustomNavContentProps } from '@veiag/payload-enhanced-sidebar'
- * import { useTabState } from '@veiag/payload-enhanced-sidebar'
+ * import { useTabState } from '@veiag/payload-enhanced-sidebar/client'
  *
  * const TabPanel = ({ id, content }: { id: string; content: React.ReactNode }) => {
  *   const { isActive } = useTabState(id)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tabs can now navigate to a URL while opening their associated panel.
  - Added support for internal, route-relative, and external tab destinations.
  - Linked tabs preserve standard browser behaviors, including modifier clicks and opening in new windows.
  - Added current-route indicators and independent navigation and panel active states.
  - Expanded client-side exports for sidebar hooks, providers, and related types.
  - Updated dashboard navigation with shortcuts and an external Documentation link.

- **Documentation**
  - Expanded guidance for linked tabs, URL handling, accessibility, and client imports.

- **Chores**
  - Updated the package version to 0.5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->